### PR TITLE
ci: split lint and pytest jobs to enforce PR pytest gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,19 @@ name: CI
 
 on:
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
-  lint-and-test:
+  lint:
     runs-on: ubuntu-latest
 
     steps:
@@ -17,6 +25,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+          cache: 'pip'
 
       - name: Install dependencies
         run: |
@@ -27,5 +36,25 @@ jobs:
       - name: Run Ruff
         run: ruff check .
 
-      - name: Run tests
-        run: pytest
+  pytest:
+    name: pytest
+    runs-on: ubuntu-latest
+    needs: lint
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .[dev]
+
+      - name: Run pytest
+        run: pytest -q


### PR DESCRIPTION
### Motivation
- Ensure pull requests must pass the test suite before merge by making `pytest` an explicit CI job that can be required in branch protection. 
- Reduce CI privileges by tightening workflow permissions to minimize blast radius. 
- Limit CI runs to relevant PR events and speed up installs by enabling pip caching in `setup-python`.

### Description
- Updated `.github/workflows/ci.yml` to restrict `pull_request` triggers and added `types` for `opened`, `synchronize`, `reopened`, and `ready_for_review` events. 
- Added minimal workflow permissions with `permissions: contents: read` in `ci.yml`. 
- Split the original `lint-and-test` job into a `lint` job (runs `ruff`) and a separate `pytest` job that `needs: lint` so `pytest` can be configured as a required status check. 
- Enabled `cache: 'pip'` in `actions/setup-python` and changed the test step to run `pytest -q`.

### Testing
- Ran the test suite locally with `pytest -q` and all tests passed (`24 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c67c723d048324ae2de47ad44bb4aa)