### PR TITLE
feat(frontend): add interactive blog graph visualization

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -25,6 +25,20 @@ export type BlogRecord = {
   updated_at: string;
 };
 
+
+export type EdgeRecord = {
+  id: number;
+  from_blog_id: number;
+  to_blog_id: number;
+  link_url_raw: string;
+  link_text: string | null;
+  discovered_at: string;
+};
+
+export type GraphPayload = {
+  nodes: BlogRecord[];
+  edges: EdgeRecord[];
+};
 export type StatusPayload = {
   is_running: boolean;
   pending_tasks: number;
@@ -69,6 +83,7 @@ export const api = {
   blogs: () => request<BlogRecord[]>("/api/blogs"),
   status: () => request<StatusPayload>("/api/status"),
   stats: () => request<StatsPayload>("/api/stats"),
+  graph: () => request<GraphPayload>("/api/graph"),
   runtimeStatus: () => request<RuntimeStatus>("/api/runtime/status"),
   runtimeCurrent: () => request<RuntimeStatus>("/api/runtime/current"),
   startCrawler: () => request<RuntimeStatus>("/api/runtime/start", { method: "POST" }),

--- a/frontend/src/lib/hooks.ts
+++ b/frontend/src/lib/hooks.ts
@@ -25,6 +25,14 @@ export function useStats() {
   });
 }
 
+
+export function useGraph() {
+  return useQuery({
+    queryKey: ["graph"],
+    queryFn: api.graph,
+    refetchInterval: 6000,
+  });
+}
 export function useRuntimeStatus() {
   return useQuery({
     queryKey: ["runtime-status"],
@@ -49,6 +57,7 @@ export function useCrawlerActions() {
       queryClient.invalidateQueries({ queryKey: ["blogs"] }),
       queryClient.invalidateQueries({ queryKey: ["status"] }),
       queryClient.invalidateQueries({ queryKey: ["stats"] }),
+      queryClient.invalidateQueries({ queryKey: ["graph"] }),
       queryClient.invalidateQueries({ queryKey: ["runtime-status"] }),
       queryClient.invalidateQueries({ queryKey: ["runtime-current"] }),
     ]);

--- a/frontend/src/pages/GraphPage.tsx
+++ b/frontend/src/pages/GraphPage.tsx
@@ -1,0 +1,171 @@
+import { useMemo, useState } from "react";
+import { PageHeader } from "../components/PageHeader";
+import { Surface } from "../components/Surface";
+import { useGraph } from "../lib/hooks";
+import type { BlogRecord, GraphPayload } from "../lib/api";
+
+type GraphNode = BlogRecord & {
+  x: number;
+  y: number;
+};
+
+type HoveredNode = {
+  id: number;
+  url: string;
+  title: string;
+  friendLinks: number;
+  outgoingCount: number;
+  incomingCount: number;
+  depth: number;
+};
+
+const VIEWPORT_WIDTH = 980;
+const VIEWPORT_HEIGHT = 540;
+const GRAPH_RADIUS = 210;
+
+function normalizeGraph(payload: GraphPayload | undefined): { nodes: GraphNode[]; edges: GraphPayload["edges"] } {
+  const nodeCount = Math.max(payload?.nodes.length ?? 1, 1);
+  const nodes = (payload?.nodes ?? []).map((node, index) => {
+    const angle = (Math.PI * 2 * index) / nodeCount;
+    return {
+      ...node,
+      x: VIEWPORT_WIDTH / 2 + Math.cos(angle) * GRAPH_RADIUS,
+      y: VIEWPORT_HEIGHT / 2 + Math.sin(angle) * GRAPH_RADIUS,
+    };
+  });
+
+  return {
+    nodes,
+    edges: payload?.edges ?? [],
+  };
+}
+
+export function GraphPage() {
+  const graph = useGraph();
+  const [hovered, setHovered] = useState<HoveredNode | null>(null);
+
+  const normalized = useMemo(() => normalizeGraph(graph.data), [graph.data]);
+  const nodeMap = useMemo(() => new Map(normalized.nodes.map((node) => [node.id, node])), [normalized.nodes]);
+
+  const outgoingById = useMemo(() => {
+    const counter = new Map<number, number>();
+    normalized.edges.forEach((edge) => {
+      counter.set(edge.from_blog_id, (counter.get(edge.from_blog_id) ?? 0) + 1);
+    });
+    return counter;
+  }, [normalized.edges]);
+
+  const incomingById = useMemo(() => {
+    const counter = new Map<number, number>();
+    normalized.edges.forEach((edge) => {
+      counter.set(edge.to_blog_id, (counter.get(edge.to_blog_id) ?? 0) + 1);
+    });
+    return counter;
+  }, [normalized.edges]);
+
+  return (
+    <div className="page-stack">
+      <PageHeader
+        eyebrow="Topology"
+        title="Blog 友链图谱"
+        description="每个 blog 显示为 node，友链显示为 edge。鼠标悬停节点可以查看 URL、标题与关联数量。"
+      />
+      <Surface title="Graph 视图" note="来自 /api/graph，基于 React + SVG 渲染">
+        {graph.isLoading ? <p>正在加载图谱…</p> : null}
+        {graph.error ? <p className="error-copy">图谱加载失败：{graph.error.message}</p> : null}
+        {!graph.isLoading && !graph.error && normalized.nodes.length === 0 ? <p>暂无图谱数据。</p> : null}
+
+        {normalized.nodes.length > 0 ? (
+          <div className="graph-layout">
+            <svg
+              className="graph-canvas"
+              viewBox={`0 0 ${VIEWPORT_WIDTH} ${VIEWPORT_HEIGHT}`}
+              role="img"
+              aria-label="Blog graph visualization"
+            >
+              {normalized.edges.map((edge) => {
+                const source = nodeMap.get(edge.from_blog_id);
+                const target = nodeMap.get(edge.to_blog_id);
+                if (!source || !target) {
+                  return null;
+                }
+                return (
+                  <line
+                    key={edge.id}
+                    x1={source.x}
+                    y1={source.y}
+                    x2={target.x}
+                    y2={target.y}
+                    className="graph-edge"
+                  />
+                );
+              })}
+
+              {normalized.nodes.map((node) => {
+                const incoming = incomingById.get(node.id) ?? 0;
+                const outgoing = outgoingById.get(node.id) ?? 0;
+                const radius = Math.max(8, Math.min(22, 8 + outgoing * 0.9));
+                return (
+                  <g
+                    key={node.id}
+                    transform={`translate(${node.x}, ${node.y})`}
+                    onMouseEnter={() =>
+                      setHovered({
+                        id: node.id,
+                        url: node.url,
+                        title: (node as BlogRecord & { title?: string }).title ?? node.domain,
+                        friendLinks: node.friend_links_count,
+                        outgoingCount: outgoing,
+                        incomingCount: incoming,
+                        depth: node.depth,
+                      })
+                    }
+                    onMouseLeave={() => setHovered(null)}
+                  >
+                    <circle r={radius} className="graph-node" />
+                  </g>
+                );
+              })}
+            </svg>
+            <aside className="graph-tooltip" aria-live="polite">
+              {hovered ? (
+                <dl className="detail-grid">
+                  <div>
+                    <dt>ID</dt>
+                    <dd>{hovered.id}</dd>
+                  </div>
+                  <div>
+                    <dt>Title</dt>
+                    <dd>{hovered.title}</dd>
+                  </div>
+                  <div>
+                    <dt>URL</dt>
+                    <dd className="url-cell">{hovered.url}</dd>
+                  </div>
+                  <div>
+                    <dt>链接 blog 数</dt>
+                    <dd>{hovered.friendLinks}</dd>
+                  </div>
+                  <div>
+                    <dt>Outgoing</dt>
+                    <dd>{hovered.outgoingCount}</dd>
+                  </div>
+                  <div>
+                    <dt>Incoming</dt>
+                    <dd>{hovered.incomingCount}</dd>
+                  </div>
+                  <div>
+                    <dt>Depth</dt>
+                    <dd>{hovered.depth}</dd>
+                  </div>
+                </dl>
+              ) : (
+                <p className="page-copy">将鼠标移动到任意节点查看详细信息。</p>
+              )}
+            </aside>
+          </div>
+        ) : null}
+      </Surface>
+    </div>
+  );
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -3,6 +3,7 @@ import { AppLayout } from "./shell/AppLayout";
 import { AboutPage } from "./pages/AboutPage";
 import { BlogsPage } from "./pages/BlogsPage";
 import { ControlPage } from "./pages/ControlPage";
+import { GraphPage } from "./pages/GraphPage";
 import { CurrentRuntimePage } from "./pages/CurrentRuntimePage";
 import { StatsPage } from "./pages/StatsPage";
 
@@ -13,6 +14,7 @@ export const router = createBrowserRouter([
     children: [
       { index: true, element: <StatsPage /> },
       { path: "blogs", element: <BlogsPage /> },
+      { path: "graph", element: <GraphPage /> },
       { path: "runtime/current", element: <CurrentRuntimePage /> },
       { path: "stats", element: <StatsPage /> },
       { path: "about", element: <AboutPage /> },

--- a/frontend/src/shell/AppLayout.tsx
+++ b/frontend/src/shell/AppLayout.tsx
@@ -3,6 +3,7 @@ import { NavLink, Outlet } from "react-router-dom";
 const navigation = [
   { to: "/stats", label: "统计总览" },
   { to: "/blogs", label: "Blog 概览" },
+  { to: "/graph", label: "关系图谱" },
   { to: "/runtime/current", label: "当前处理" },
   { to: "/control", label: "控制台" },
   { to: "/about", label: "项目介绍" },

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -275,3 +275,47 @@ td {
     border-bottom: 1px solid rgba(214, 200, 172, 0.6);
   }
 }
+
+.graph-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(280px, 1fr);
+  gap: 16px;
+}
+
+.graph-canvas {
+  width: 100%;
+  min-height: 420px;
+  border-radius: 18px;
+  border: 1px solid rgba(214, 200, 172, 0.8);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.65), rgba(251, 247, 240, 0.95));
+}
+
+.graph-edge {
+  stroke: rgba(111, 92, 68, 0.45);
+  stroke-width: 1.2;
+}
+
+.graph-node {
+  fill: rgba(194, 96, 31, 0.85);
+  stroke: rgba(158, 65, 18, 0.95);
+  stroke-width: 1.5;
+  cursor: pointer;
+  transition: transform 120ms ease;
+}
+
+.graph-node:hover {
+  fill: rgba(158, 65, 18, 0.95);
+}
+
+.graph-tooltip {
+  border-radius: 18px;
+  border: 1px solid rgba(214, 200, 172, 0.8);
+  background: rgba(255, 252, 246, 0.85);
+  padding: 14px;
+}
+
+@media (max-width: 1200px) {
+  .graph-layout {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a visual topology view where each blog is a node and friend links are edges so operators can inspect relationships and node metadata quickly. 
- Surface node details (URL, title/domain fallback, friend link counts, in/out-degree, depth) on hover to aid debugging and exploration. 

### Description
- Add a new page `GraphPage` at route `/graph` that renders nodes and edges as an SVG-based graph and shows a detail panel when the mouse hovers over a node (`frontend/src/pages/GraphPage.tsx`).
- Wire a new API model and endpoint call by adding `EdgeRecord` and `GraphPayload` types and `api.graph()` to `frontend/src/lib/api.ts` so the page reads `/api/graph` from the backend. 
- Add a `useGraph` React Query hook and include `graph` in the crawler action cache invalidation set so the graph refreshes after crawler operations (`frontend/src/lib/hooks.ts`).
- Register the page in the app router and sidebar (`frontend/src/router.tsx`, `frontend/src/shell/AppLayout.tsx`) and add styles for canvas, nodes, edges and responsive layout (`frontend/src/styles.css`).
- The implementation uses a deterministic circular SVG layout for node placement to avoid additional runtime dependencies; an attempt to install a force-layout package failed in this environment, so layout is intentionally simple and dependency-free.

### Testing
- Ran backend unit tests: `pytest -q tests/test_repository.py tests/test_service_split.py` which completed successfully (all tests passed).
- Ran frontend test runner: `npm test` returned an environment error (`vitest` binary not found), so frontend test execution did not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9563b573c8324b36d7e6136443155)